### PR TITLE
fix(ci): Corrige el despliegue de GitHub Pages

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -237,10 +237,14 @@ jobs:
             git push --set-upstream https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git master
           fi
 
+      - name: Prepare artifact for deployment
+        run: |
+          mkdir -p _site
+          mv docs/* _site/
       - name: Upload artifacts
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs
+          path: _site
 
   deploy-pages:
     needs: generate-docs


### PR DESCRIPTION
## Descripción
Este Pull Request corrige un problema en el pipeline de despliegue de GitHub Pages que no fue solucionado en el PR #24 debido a que se hizo merge antes de que el commit de corrección fuera pusheado.

El problema original causaba un error 404 en el sitio de GitHub Pages porque el artefacto de despliegue no tenía el archivo `index.html` en su raíz.

## Cambios Realizados
- [x] Se ajusta el workflow `generate-docs.yml` para mover el contenido de la carpeta `docs` a un directorio `_site`.
- [x] Se sube el directorio `_site` como el artefacto de despliegue, asegurando la estructura de archivos correcta.

## Verificación
1.  Al abrir este PR, el workflow `Generate Documentation` debería ejecutarse.
2.  El job `deploy-pages` (que se ejecuta en el preview del PR) debería completarse exitosamente.
3.  La URL de preview de GitHub Pages generada por la acción debería mostrar el `index.html` correctamente, sin un error 404.

Este PR reemplaza la corrección intentada en el commit `b72845a`.
