### PR TITLE
chore(release): prepare version 0.6.1

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -30,7 +30,9 @@ jobs:
           cache: maven
 
       - name: Generate Dependency Tree
-        run: mvn dependency:tree -DoutputFile=docs/dependency-tree.txt
+        run: |
+          mkdir -p docs
+          mvn dependency:tree -DoutputFile=docs/dependency-tree.txt
 
       - name: Generate Project Documentation
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [0.5.0] - 2025-07-24
+## [0.6.1] - 2025-09-21
+- chore: Update Spring Boot Starter Parent to 3.5.6
+- chore: Update springdoc-openapi-starter-webmvc-ui to 2.8.10
+- refactor: Replace manual constructor with @RequiredArgsConstructor in ProgramaDiaService
+
 ## [0.6.0] - 2025-08-05
  - feat: Migración completa de Eureka a Consul como discovery service (bootstrap.yml, pom.xml)
  - feat: Añadido soporte para importación automática de programas completados vía scheduler (ImportWebDataScheduler)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ETEREA.programa-dia-service
 
-**Versión:** 0.6.0  
-**Fecha de lanzamiento:** 2025-08-05
+**Versión:** 0.6.1
+**Fecha de lanzamiento:** 2025-09-21
 
 [![ETEREA.programa-dia-service CI](https://github.com/ETEREA-services/ETEREA.programa-dia-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/ETEREA.programa-dia-service/actions/workflows/maven.yml)
 ![Java](https://img.shields.io/badge/Java-24-blue.svg)
-![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.4-green.svg)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.6-green.svg)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.0-blue.svg)](https://spring.io/projects/spring-cloud)
 [![Maven](https://img.shields.io/badge/Maven-3.9.9-orange.svg)](https://maven.apache.org/)
 [![Docker](https://img.shields.io/badge/Docker-✓-blue.svg)](https://www.docker.com/)
@@ -13,12 +13,9 @@
 
 ## Cambios recientes
 
-- Migración completa de Eureka a Consul como discovery service.
-- Añadido soporte para importación automática de programas completados vía scheduler.
-- Nuevos DTOs y métodos de serialización JSON.
-- Añadido deserializador personalizado para OffsetDateTime.
-- Actualización de Spring Boot Starter Parent a 3.5.4.
-- Nuevos tests unitarios y mejoras en logging.
+- Actualización de Spring Boot Starter Parent a 3.5.6.
+- Actualización de springdoc-openapi-starter-webmvc-ui a 2.8.10.
+- Refactor en ProgramaDiaService para usar @RequiredArgsConstructor.
 
 ## Descripción del Proyecto
 ETEREA.programa-dia-service es un servicio de backend desarrollado en Java utilizando Spring Boot. Este servicio gestiona la lógica de negocio relacionada con el programa del día, incluyendo la gestión de vouchers, reservas, clientes y manejo de diferencias en precios web.

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>eterea</groupId>
     <artifactId>programa-dia-service</artifactId>
-    <version>0.4.0</version>
+    <version>0.6.1</version>
     <name>ETEREA.programa-dia-service</name>
     <description>eterea.programa-dia-service</description>
     <url/>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.9</version>
+            <version>2.8.10</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/eterea/programa/dia/service/service/facade/ProgramaDiaService.java
+++ b/src/main/java/eterea/programa/dia/service/service/facade/ProgramaDiaService.java
@@ -7,6 +7,7 @@ import eterea.programa.dia.service.domain.dto.*;
 import eterea.programa.dia.service.domain.dto.extern.OrderNoteDto;
 import eterea.programa.dia.service.exception.ProgramaDiaException;
 import eterea.programa.dia.service.service.util.RequestUuidHolder;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -17,6 +18,7 @@ import java.util.stream.Collectors;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class ProgramaDiaService {
 
     private final VoucherClient voucherClient;
@@ -29,25 +31,6 @@ public class ProgramaDiaService {
 
     private final OrderNoteService orderNoteService;
     private final TrackClient trackClient;
-
-    public ProgramaDiaService(VoucherClient voucherClient,
-                              ClienteMovimientoClient clienteMovimientoClient,
-                              ReservaOrigenClient reservaOrigenClient,
-                              EmpresaClient empresaClient,
-                              ReservaContextClient reservaContextClient,
-                              VouchersClient vouchersClient,
-                              MakeFacturaProgramaDiaClient makeFacturaProgramaDiaClient,
-                              OrderNoteService orderNoteService, TrackClient trackClient) {
-        this.voucherClient = voucherClient;
-        this.clienteMovimientoClient = clienteMovimientoClient;
-        this.reservaOrigenClient = reservaOrigenClient;
-        this.empresaClient = empresaClient;
-        this.orderNoteService = orderNoteService;
-        this.reservaContextClient = reservaContextClient;
-        this.vouchersClient = vouchersClient;
-        this.makeFacturaProgramaDiaClient = makeFacturaProgramaDiaClient;
-        this.trackClient = trackClient;
-    }
 
     public ProgramaDiaDto findAllByFechaServicio(OffsetDateTime fechaServicio, Boolean soloConfirmados,
                                                  Boolean porNombrePax) {


### PR DESCRIPTION
## Descripción
Este PR prepara la liberación de la versión 0.6.1 del servicio ETEREA.programa-dia-service. Incluye actualizaciones de dependencias, refactorización de código, correcciones en el pipeline de CI/CD y actualización de la documentación. Resuelve la issue #39.

## Cambios Realizados
- [x] Actualización de Spring Boot Starter Parent de 3.5.4 a 3.5.6
- [x] Actualización de springdoc-openapi-starter-webmvc-ui de 2.8.9 a 2.8.10
- [x] Refactorización de ProgramaDiaService para usar @RequiredArgsConstructor en lugar de constructor manual
- [x] Corrección en generate-docs.yml para crear el directorio docs antes de generar el árbol de dependencias
- [x] Bump de versión en pom.xml a 0.6.1
- [x] Actualización de CHANGELOG.md con entrada para versión 0.6.1
- [x] Actualización de README.md con versión, fecha, badge de Spring Boot y cambios recientes

## Impacto Potencial
- [x] Los cambios en dependencias son versiones patch/minor, sin breaking changes
- [x] La refactorización mejora la mantenibilidad sin alterar funcionalidad
- [x] La corrección en CI asegura que el pipeline de documentación funcione correctamente
- [x] No se requieren migraciones de base de datos ni cambios en variables de entorno

## Verificación
Para verificar los cambios:
1. `git checkout 39-release-061---dependency-updates-and-refactoring`
2. `mvn clean compile` - Verificar que el proyecto compile correctamente
3. `mvn test` - Ejecutar tests para asegurar que no se rompió nada
4. Revisar que el pipeline de CI pase en GitHub Actions

## Notas Adicionales
Este PR es parte del milestone "Versión 0.6.1 - Release". Los cambios han sido probados localmente y el commit sigue Conventional Commits.