### PR TITLE
feat(build): update Java to 25, Spring Boot to 3.5.8, and scheduler frequency

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,10 +18,10 @@ jobs:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.7.0] - 2026-01-06
+- chore: Update Java version to 25
+- chore: Update Spring Boot Starter Parent to 3.5.8
+- feat: Change ImportWebDataScheduler cron from hourly to every 10 minutes
+
 ## [0.6.1] - 2025-09-21
 - chore: Update Spring Boot Starter Parent to 3.5.6
 - chore: Update springdoc-openapi-starter-webmvc-ui to 2.8.10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Etapa 1: Compilación con Maven y JDK
 # Usamos una imagen oficial que contiene Maven y Java (Temurin)
-FROM maven:3-eclipse-temurin-24-alpine AS build
+FROM maven:3-eclipse-temurin-25-alpine AS build
 
 # Establecemos el directorio de trabajo
 WORKDIR /app
@@ -19,7 +19,7 @@ RUN mvn clean package
 
 # Etapa 2: Creación de la imagen final y ligera
 # Usamos una imagen solo con el JRE, que es más pequeña
-FROM eclipse-temurin:24-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 
 # Instalar curl en la imagen final
 RUN apk update && apk add curl

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ETEREA.programa-dia-service
 
-**Versión:** 0.6.1
-**Fecha de lanzamiento:** 2025-09-21
+**Versión:** 0.7.0
+**Fecha de lanzamiento:** 2026-01-06
 
 [![ETEREA.programa-dia-service CI](https://github.com/ETEREA-services/ETEREA.programa-dia-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/ETEREA.programa-dia-service/actions/workflows/maven.yml)
-![Java](https://img.shields.io/badge/Java-24-blue.svg)
-![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.6-green.svg)
+![Java](https://img.shields.io/badge/Java-25-blue.svg)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.8-green.svg)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.0-blue.svg)](https://spring.io/projects/spring-cloud)
 [![Maven](https://img.shields.io/badge/Maven-3.9.9-orange.svg)](https://maven.apache.org/)
 [![Docker](https://img.shields.io/badge/Docker-✓-blue.svg)](https://www.docker.com/)
@@ -13,9 +13,9 @@
 
 ## Cambios recientes
 
-- Actualización de Spring Boot Starter Parent a 3.5.6.
-- Actualización de springdoc-openapi-starter-webmvc-ui a 2.8.10.
-- Refactor en ProgramaDiaService para usar @RequiredArgsConstructor.
+- Actualización de Java a versión 25.
+- Actualización de Spring Boot Starter Parent a 3.5.8.
+- Cambio en el scheduler de importación web para ejecutarse cada 10 minutos en lugar de cada hora.
 
 ## Descripción del Proyecto
 ETEREA.programa-dia-service es un servicio de backend desarrollado en Java utilizando Spring Boot. Este servicio gestiona la lógica de negocio relacionada con el programa del día, incluyendo la gestión de vouchers, reservas, clientes y manejo de diferencias en precios web.
@@ -30,7 +30,7 @@ ETEREA.programa-dia-service es un servicio de backend desarrollado en Java utili
 -- Integración con Spring Cloud y Consul
 
 ## Requisitos Previos
-- Java 24
+- Java 25
 - Maven 3.9.9
 - Docker (opcional, para despliegue en contenedores)
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.6</version>
+        <version>3.5.8</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>eterea</groupId>
     <artifactId>programa-dia-service</artifactId>
-    <version>0.6.1</version>
+    <version>0.7.0</version>
     <name>ETEREA.programa-dia-service</name>
     <description>eterea.programa-dia-service</description>
     <url/>
@@ -27,7 +27,7 @@
         <url/>
     </scm>
     <properties>
-        <java.version>24</java.version>
+        <java.version>25</java.version>
         <sonar.organization>eterea-services</sonar.organization>
         <sonar.projectKey>ETEREA-services_ETEREA.programa-dia-service</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/src/main/java/eterea/programa/dia/service/scheduler/ImportWebDataScheduler.java
+++ b/src/main/java/eterea/programa/dia/service/scheduler/ImportWebDataScheduler.java
@@ -17,7 +17,7 @@ public class ImportWebDataScheduler {
         this.service = service;
     }
 
-    @Scheduled(cron = "0 30 * * * *")
+    @Scheduled(cron = "0 0/10 * * * ?")
     public void importManyCompletedFromWebScheduled() {
         service.importManyCompletedFromWeb();
     }


### PR DESCRIPTION
## Descripción
This PR updates the Java version to 25, Spring Boot Starter Parent to 3.5.8, and adjusts the ImportWebDataScheduler cron from hourly to every 10 minutes for more frequent data imports.

## Cambios Realizados
- [x] Updated Java version to 25 in pom.xml
- [x] Updated Spring Boot Starter Parent to 3.5.8
- [x] Changed ImportWebDataScheduler cron from "0 0 * * * ?" to "0 0/10 * * * ?" for every 10 minutes execution

## Impacto Potencial
- [ ] Potential compatibility issues with Java 25; ensure runtime environment supports it
- [ ] Increased frequency of scheduled task may affect system load; monitor performance
- [ ] No database migrations required

## Verificación
Provide the exact steps for a reviewer to test the changes locally.
1. `git checkout 41-release-070-update-java-to-25-spring-boot-to-358-and-adjust-scheduler-frequency`
2. `mvn clean compile`
3. `mvn test`
4. Start the application with `mvn spring-boot:run` and verify it starts without errors
5. Check that the scheduler runs every 10 minutes (monitor logs for importManyCompletedFromWebScheduled execution)

## Notas Adicionales
- This release is version 0.7.0 as per CHANGELOG.md
- No breaking changes expected, but recommend testing in staging environment