### PR TITLE
release(project): upgrade to Spring Boot 4.0.6, Spring Cloud 2025.1.0, DTO refactor and CI/CD updates

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -18,21 +18,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 24
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 
       - name: Generate Dependency Tree
-        run: |
-          mkdir -p docs
-          mvn dependency:tree -DoutputFile=docs/dependency-tree.txt
+        run: mvn dependency:tree -DoutputFile=docs/dependency-tree.txt
 
       - name: Generate Project Documentation
         env:
@@ -267,14 +265,10 @@ jobs:
             git push --set-upstream https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git master
           fi
 
-      - name: Prepare artifact for deployment
-        run: |
-          mkdir -p _site
-          mv docs/* _site/
       - name: Upload artifacts
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
-          path: _site
+          path: docs
 
   deploy-pages:
     needs: generate-docs
@@ -289,4 +283,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
+

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,24 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -54,17 +54,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata for JVM Docker image
         id: meta-jvm
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKER_IMAGE_NAME }}
           # Add a '-jvm' suffix to tags to differentiate them
@@ -75,10 +75,10 @@ jobs:
             latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push JVM Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           # Point to the new JVM-specific Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [1.0.0] - 2026-05-30
+- feat: Actualización de Spring Boot Starter Parent de 3.5.8 a 4.0.6 (major)
+- feat: Actualización de Spring Cloud de 2025.0.0 a 2025.1.0
+- feat: Actualización de springdoc-openapi de 2.8.10 a 3.0.2 (major)
+- feat: Nuevo test dependency spring-boot-starter-webmvc-test con relocalización de WebMvcTest
+- feat: Refactor de todos los DTOs: @Data reemplazado por @Getter/@Setter/@Builder/@NoArgsConstructor/@AllArgsConstructor
+- feat: Refactor de controladores y servicios: constructores manuales reemplazados por @RequiredArgsConstructor
+- feat: Refactor de ResponseEntity: uso de helpers (ResponseEntity.ok()) en lugar de new ResponseEntity<>()
+- chore: Eliminación de dependencia spring-boot-starter-aop
+- chore: Eliminación de configuración executable=true en spring-boot-maven-plugin
+- chore: Actualización de commons-lang3 a 3.20.0
+- chore: Nueva dependencia commons-fileupload 1.6.0 en dependencyManagement
+- chore: Actualización de GitHub Actions a checkout@v6, setup-java@v5, cache@v5, docker/*@v4/v6/v7, deploy-pages@v5
+- fix: Simplificación del path de artefacto en pipeline de documentación
+
 ## [0.7.0] - 2026-01-06
 - chore: Update Java version to 25
 - chore: Update Spring Boot Starter Parent to 3.5.8

--- a/README.md
+++ b/README.md
@@ -1,21 +1,28 @@
 # ETEREA.programa-dia-service
 
-**Versión:** 0.7.0
-**Fecha de lanzamiento:** 2026-01-06
+**Versión:** 1.0.0
+**Fecha de lanzamiento:** 2026-05-30
 
 [![ETEREA.programa-dia-service CI](https://github.com/ETEREA-services/ETEREA.programa-dia-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/ETEREA.programa-dia-service/actions/workflows/maven.yml)
 ![Java](https://img.shields.io/badge/Java-25-blue.svg)
-![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.8-green.svg)
-[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.0-blue.svg)](https://spring.io/projects/spring-cloud)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.6-green.svg)
+[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-blue.svg)](https://spring.io/projects/spring-cloud)
 [![Maven](https://img.shields.io/badge/Maven-3.9.9-orange.svg)](https://maven.apache.org/)
 [![Docker](https://img.shields.io/badge/Docker-✓-blue.svg)](https://www.docker.com/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-yellow.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Cambios recientes
 
-- Actualización de Java a versión 25.
-- Actualización de Spring Boot Starter Parent a 3.5.8.
-- Cambio en el scheduler de importación web para ejecutarse cada 10 minutos en lugar de cada hora.
+- Actualización de Spring Boot Starter Parent a 4.0.6.
+- Actualización de Spring Cloud a 2025.1.0.
+- Actualización de springdoc-openapi a 3.0.2 (con cambio de paquete para WebMvcTest).
+- Eliminación de dependencia spring-boot-starter-aop.
+- Refactor de todos los DTOs: reemplazo de @Data por anotaciones explícitas (@Getter, @Setter, @Builder, @NoArgsConstructor, @AllArgsConstructor).
+- Refactor de controladores y servicios: reemplazo de constructores manuales por @RequiredArgsConstructor.
+- Refactor de ResponseEntity: uso de helpers (ResponseEntity.ok()) en lugar de constructor directo.
+- Nuevas dependencias: spring-boot-starter-webmvc-test, commons-fileupload 1.6.0.
+- Actualización de commons-lang3 a 3.20.0.
+- Actualización de GitHub Actions a versiones más recientes.
 
 ## Descripción del Proyecto
 ETEREA.programa-dia-service es un servicio de backend desarrollado en Java utilizando Spring Boot. Este servicio gestiona la lógica de negocio relacionada con el programa del día, incluyendo la gestión de vouchers, reservas, clientes y manejo de diferencias en precios web.
@@ -27,7 +34,7 @@ ETEREA.programa-dia-service es un servicio de backend desarrollado en Java utili
 - API REST para integración con otros servicios
 - Documentación automática con GitHub Pages y Wiki
 - Sistema de logs mejorado
--- Integración con Spring Cloud y Consul
+- Integración con Spring Cloud y Consul
 
 ## Requisitos Previos
 - Java 25

--- a/docs/diagrams/data-model.mmd
+++ b/docs/diagrams/data-model.mmd
@@ -1,26 +1,77 @@
 classDiagram
     class ProgramaDiaDto {
-        +FacturaDto factura
         +List~VoucherDto~ vouchers
-        +OrderNoteDto orderNote
-    }
-
-    class FacturaDto {
-        +String numero
-        +String fecha
-        +ClienteDto cliente
+        +List~ReservaOrigenDto~ reservaOrigens
+        +List~ClienteMovimientoDto~ clienteMovimientos
+        +String errorMessage
     }
 
     class VoucherDto {
-        +String codigo
-        +String servicio
+        +Long voucherId
+        +OffsetDateTime fechaServicio
+        +String nombrePax
+        +Integer paxs
+        +String productos
+        +Long reservaId
+        +String numeroVoucher
     }
 
-    class OrderNoteDto {
-        +String id
-        +List~ProductTransactionDto~ transactions
+    class ReservaOrigenDto {
+        +Integer reservaOrigenId
+        +String nombre
     }
 
-    ProgramaDiaDto "1" -- "1" FacturaDto : contiene
+    class ClienteMovimientoDto {
+        +Long clienteMovimientoId
+        +Long reservaId
+        +BigDecimal importe
+        +ComprobanteDto comprobante
+        +ClienteDto cliente
+    }
+
+    class ClienteDto {
+        +Long clienteId
+        +String nombre
+        +String cuit
+        +String razonSocial
+    }
+
+    class ReservaDto {
+        +Long reservaId
+        +String nombrePax
+        +BigDecimal diferenciaWeb
+        +ClienteDto cliente
+    }
+
+    class ComprobanteDto {
+        +Integer comprobanteId
+    }
+
+    class HotelDto {
+        +Integer hotelId
+    }
+
+    class ProveedorDto {
+        +Long proveedorId
+    }
+
+    class UsuarioDto {
+        +String login
+    }
+
+    class MonedaDto {
+        +Integer monedaId
+    }
+
     ProgramaDiaDto "1" -- "N" VoucherDto : contiene
-    ProgramaDiaDto "1" -- "1" OrderNoteDto : contiene
+    ProgramaDiaDto "1" -- "N" ReservaOrigenDto : contiene
+    ProgramaDiaDto "1" -- "N" ClienteMovimientoDto : contiene
+    VoucherDto "1" -- "1" ClienteDto : tiene
+    VoucherDto "1" -- "1" HotelDto : tiene
+    VoucherDto "1" -- "1" ProveedorDto : tiene
+    VoucherDto "1" -- "1" ReservaDto : tiene
+    VoucherDto "1" -- "1" UsuarioDto : tiene
+    ReservaDto "1" -- "1" ClienteDto : tiene
+    ClienteMovimientoDto "1" -- "1" ComprobanteDto : tiene
+    ClienteMovimientoDto "1" -- "1" ClienteDto : tiene
+    ClienteMovimientoDto "1" -- "1" MonedaDto : tiene

--- a/docs/diagrams/sequence-flow.mmd
+++ b/docs/diagrams/sequence-flow.mmd
@@ -2,27 +2,80 @@ sequenceDiagram
     actor C as Client
     participant PDC as ProgramaDiaController
     participant PDS as ProgramaDiaService
-    participant MFF as MakeFacturaClient
-    participant VC as VouchersClient
+    participant VC as VoucherClient
+    participant ROC as ReservaOrigenClient
+    participant CMC as ClienteMovimientoClient
     participant ONC as OrderNoteClient
+    participant VFC as VouchersClient (Feign)
+    participant TC as TrackClient
+    participant MFPC as MakeFacturaProgramaDiaClient
 
-    C->>PDC: GET /programa-dia/{id}
+    Note over C,MFPC: Flujo: findAllByFechaServicio
+    C->>PDC: GET /fechaServicio/{fecha}/{soloConfirmados}/{porNombrePax}
     activate PDC
-    PDC->>PDS: getProgramaDia(id)
+    PDC->>PDS: findAllByFechaServicio(fecha, soloConfirmados, porNombrePax)
     activate PDS
-    PDS->>MFF: makeFactura(id)
-    activate MFF
-    MFF-->>PDS: FacturaDto
-    deactivate MFF
-    PDS->>VC: getVouchers(id)
+    PDS->>VC: findAllByFechaServicio(...)
     activate VC
-    VC-->>PDS: List of VoucherDto
+    VC-->>PDS: List~VoucherDto~
     deactivate VC
-    PDS->>ONC: getOrderNote(id)
-    activate ONC
-    ONC-->>PDS: OrderNoteDto
-    deactivate ONC
+    PDS->>CMC: findAllByReservaIds(reservaIds)
+    activate CMC
+    CMC-->>PDS: List~ClienteMovimientoDto~
+    deactivate CMC
+    PDS->>ROC: findAll()
+    activate ROC
+    ROC-->>PDS: List~ReservaOrigenDto~
+    deactivate ROC
     PDS-->>PDC: ProgramaDiaDto
     deactivate PDS
     PDC-->>C: 200 OK (ProgramaDiaDto)
+    deactivate PDC
+
+    Note over C,MFPC: Flujo: findByVoucherId
+    C->>PDC: GET /voucher/{voucherId}
+    activate PDC
+    PDC->>PDS: findByVoucherId(voucherId)
+    activate PDS
+    PDS->>VC: findByVoucherId(voucherId)
+    activate VC
+    VC-->>PDS: VoucherDto
+    deactivate VC
+    PDS->>ROC: findByReservaOrigenId(origenId)
+    activate ROC
+    ROC-->>PDS: ReservaOrigenDto
+    deactivate ROC
+    PDS->>CMC: findAllByReservaId(reservaId)
+    activate CMC
+    CMC-->>PDS: List~ClienteMovimientoDto~
+    deactivate CMC
+    PDS-->>PDC: ProgramaDiaDto
+    deactivate PDS
+    PDC-->>C: 200 OK (ProgramaDiaDto)
+    deactivate PDC
+
+    Note over C,MFPC: Flujo: importOneFromWeb / importManyCompletedFromWeb
+    C->>PDC: GET /importOneFromWeb/{orderNumberId}
+    activate PDC
+    PDC->>PDS: importOneFromWeb(orderNumberId)
+    activate PDS
+    PDS->>ONC: findByOrderNumberId(orderNumberId)
+    activate ONC
+    ONC-->>PDS: OrderNoteDto
+    deactivate ONC
+    PDS->>TC: startTracking("import-one-from-web-...")
+    activate TC
+    TC-->>PDS: TrackDto
+    deactivate TC
+    PDS->>VFC: importOneFromWeb(orderNumberId)
+    activate VFC
+    VFC-->>PDS: ProgramaDiaDto
+    deactivate VFC
+    PDS->>MFPC: facturaReserva(reservaId, 853)
+    activate MFPC
+    MFPC-->>PDS: Boolean (isFacturado)
+    deactivate MFPC
+    PDS-->>PDC: void
+    deactivate PDS
+    PDC-->>C: 200 OK
     deactivate PDC

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.8</version>
+        <version>4.0.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>eterea</groupId>
     <artifactId>programa-dia-service</artifactId>
-    <version>0.7.0</version>
+    <version>1.0.0</version>
     <name>ETEREA.programa-dia-service</name>
     <description>eterea.programa-dia-service</description>
     <url/>
@@ -32,16 +32,12 @@
         <sonar.projectKey>ETEREA-services_ETEREA.programa-dia-service</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-        <spring-cloud.version>2025.0.0</spring-cloud.version>
+        <spring-cloud.version>2025.1.0</spring-cloud.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -71,7 +67,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.10</version>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -96,6 +92,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -103,7 +104,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
+                <version>3.20.0</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
@@ -111,6 +112,11 @@
                 <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>commons-fileupload</groupId>
+                <artifactId>commons-fileupload</artifactId>
+                <version>1.6.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -121,9 +127,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <executable>true</executable>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/eterea/programa/dia/service/controller/facade/ProgramaDiaController.java
+++ b/src/main/java/eterea/programa/dia/service/controller/facade/ProgramaDiaController.java
@@ -3,6 +3,7 @@ package eterea.programa.dia.service.controller.facade;
 import eterea.programa.dia.service.domain.dto.ProgramaDiaDto;
 import eterea.programa.dia.service.exception.ProgramaDiaException;
 import eterea.programa.dia.service.service.facade.ProgramaDiaService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,26 +17,22 @@ import java.time.OffsetDateTime;
 
 @RestController
 @RequestMapping({"/api/programa-dia/programaDia", "/programaDia"})
+@RequiredArgsConstructor
 public class ProgramaDiaController {
 
     private final ProgramaDiaService service;
-
-    public ProgramaDiaController(ProgramaDiaService service) {
-        this.service = service;
-    }
 
     @GetMapping("/fechaServicio/{fechaServicio}/{soloConfirmados}/{porNombrePax}")
     public ResponseEntity<ProgramaDiaDto> findAllByFecha(
             @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime fechaServicio,
             @PathVariable Boolean soloConfirmados, @PathVariable Boolean porNombrePax) {
-        return new ResponseEntity<>(
-                service.findAllByFechaServicio(fechaServicio, soloConfirmados, porNombrePax), HttpStatus.OK);
+        return ResponseEntity.ok(service.findAllByFechaServicio(fechaServicio, soloConfirmados, porNombrePax));
     }
 
     @GetMapping("/voucher/{voucherId}")
     public ResponseEntity<ProgramaDiaDto> findByVoucherId(@PathVariable Long voucherId) {
         try {
-            return new ResponseEntity<>(service.findByVoucherId(voucherId), HttpStatus.OK);
+            return ResponseEntity.ok(service.findByVoucherId(voucherId));
         } catch (ProgramaDiaException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         }
@@ -44,13 +41,13 @@ public class ProgramaDiaController {
     @GetMapping("/importOneFromWeb/{orderNumberId}")
     public ResponseEntity<Void> importOneFromWeb(@PathVariable Long orderNumberId) {
         service.importOneFromWeb(orderNumberId, null);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/importManyCompletedFromWeb")
     public ResponseEntity<Void> importManyCompletedFromWeb() {
         service.importManyCompletedFromWeb();
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/eterea/programa/dia/service/domain/dto/ClienteDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/ClienteDto.java
@@ -1,12 +1,16 @@
 package eterea.programa.dia.service.domain.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.Data;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
-@Data
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ClienteDto {
 
     private Long clienteId;

--- a/src/main/java/eterea/programa/dia/service/domain/dto/ClienteMovimientoDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/ClienteMovimientoDto.java
@@ -1,12 +1,16 @@
 package eterea.programa.dia.service.domain.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.Data;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
-@Data
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ClienteMovimientoDto {
 
     private Long clienteMovimientoId;

--- a/src/main/java/eterea/programa/dia/service/domain/dto/ComprobanteDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/ComprobanteDto.java
@@ -1,9 +1,12 @@
 package eterea.programa.dia.service.domain.dto;
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ComprobanteDto {
 
     private Integer comprobanteId;

--- a/src/main/java/eterea/programa/dia/service/domain/dto/CuentaDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/CuentaDto.java
@@ -1,10 +1,14 @@
 package eterea.programa.dia.service.domain.dto;
 
-import lombok.Data;
+import lombok.*;
 
 import java.math.BigDecimal;
 
-@Data
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CuentaDto {
 
     private Long numeroCuenta;

--- a/src/main/java/eterea/programa/dia/service/domain/dto/EmpresaDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/EmpresaDto.java
@@ -1,10 +1,12 @@
 package eterea.programa.dia.service.domain.dto;
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
+@Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class EmpresaDto {
 
     private Integer empresaId;

--- a/src/main/java/eterea/programa/dia/service/domain/dto/HotelDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/HotelDto.java
@@ -1,8 +1,12 @@
 package eterea.programa.dia.service.domain.dto;
 
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class HotelDto {
 
     private Integer hotelId;

--- a/src/main/java/eterea/programa/dia/service/domain/dto/MonedaDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/MonedaDto.java
@@ -1,8 +1,12 @@
 package eterea.programa.dia.service.domain.dto;
 
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class MonedaDto {
 
     private Integer monedaId;

--- a/src/main/java/eterea/programa/dia/service/domain/dto/ProgramaDiaDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/ProgramaDiaDto.java
@@ -2,14 +2,12 @@ package eterea.programa.dia.service.domain.dto;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
-@Data
+@Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/eterea/programa/dia/service/domain/dto/ProveedorDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/ProveedorDto.java
@@ -1,8 +1,12 @@
 package eterea.programa.dia.service.domain.dto;
 
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProveedorDto {
 
     private Long proveedorId;

--- a/src/main/java/eterea/programa/dia/service/domain/dto/ReservaContextDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/ReservaContextDto.java
@@ -2,14 +2,12 @@ package eterea.programa.dia.service.domain.dto;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 
-@Data
+@Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/eterea/programa/dia/service/domain/dto/ReservaDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/ReservaDto.java
@@ -1,14 +1,18 @@
 package eterea.programa.dia.service.domain.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.Data;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.Date;
 
-@Data
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ReservaDto {
 
     private Long reservaId;

--- a/src/main/java/eterea/programa/dia/service/domain/dto/ReservaOrigenDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/ReservaOrigenDto.java
@@ -1,11 +1,9 @@
 package eterea.programa.dia.service.domain.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-@Data
+@Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/eterea/programa/dia/service/domain/dto/TrackDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/TrackDto.java
@@ -4,7 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import lombok.*;
 
-@Data
+@Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/eterea/programa/dia/service/domain/dto/UsuarioDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/UsuarioDto.java
@@ -1,8 +1,12 @@
 package eterea.programa.dia.service.domain.dto;
 
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class UsuarioDto {
 
     private String login;

--- a/src/main/java/eterea/programa/dia/service/domain/dto/VoucherDto.java
+++ b/src/main/java/eterea/programa/dia/service/domain/dto/VoucherDto.java
@@ -1,12 +1,16 @@
 package eterea.programa.dia.service.domain.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.Data;
+import lombok.*;
 
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 
-@Data
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class VoucherDto {
 
     private Long voucherId;

--- a/src/main/java/eterea/programa/dia/service/service/facade/OrderNoteService.java
+++ b/src/main/java/eterea/programa/dia/service/service/facade/OrderNoteService.java
@@ -2,19 +2,17 @@ package eterea.programa.dia.service.service.facade;
 
 import eterea.programa.dia.service.client.web.OrderNoteClient;
 import eterea.programa.dia.service.domain.dto.extern.OrderNoteDto;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class OrderNoteService {
 
     private final OrderNoteClient orderNoteClient;
-
-    public OrderNoteService(OrderNoteClient orderNoteClient) {
-        this.orderNoteClient = orderNoteClient;
-    }
 
     public OrderNoteDto findByOrderNumberId(@PathVariable Long orderNumberId) {
         return orderNoteClient.findByOrderNumberId(orderNumberId);

--- a/src/test/java/eterea/programa/dia/service/controller/facade/ProgramaDiaControllerTest.java
+++ b/src/test/java/eterea/programa/dia/service/controller/facade/ProgramaDiaControllerTest.java
@@ -6,7 +6,7 @@ import eterea.programa.dia.service.service.facade.ProgramaDiaService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;


### PR DESCRIPTION
Closes #43

## Descripción

Release **v1.0.0** con actualización mayor de dependencias, refactorización integral de DTOs y controladores, y modernización del pipeline CI/CD.

## Cambios Realizados

- **Dependencias (Major):** Spring Boot `3.5.8` → `4.0.6`, Spring Cloud `2025.0.0` → `2025.1.0`, springdoc-openapi `2.8.10` → `3.0.2`
- **DTOs:** Reemplazo de `@Data` por anotaciones explícitas (`@Getter`, `@Setter`, `@Builder`, `@NoArgsConstructor`, `@AllArgsConstructor`) en 14 DTOs
- **Controladores/Servicios:** Constructores manuales reemplazados por `@RequiredArgsConstructor`
- **ResponseEntity:** Uso de helpers (`ResponseEntity.ok()`) en lugar de `new ResponseEntity<>()`
- **CI/CD:** Actualización de 9 GitHub Actions a sus versiones más recientes
- **Documentación:** CHANGELOG.md, README.md y diagramas Mermaid actualizados
- **Limpieza:** Eliminación de `spring-boot-starter-aop` y `executable=true` en plugin

## Verificación

- [ ] Build: `mvn clean verify` debe pasar con Java 25
- [ ] Tests unitarios y de integración en suite existente
- [ ] Docker build local verifica los nuevos workflows
- [ ] Compatibilidad de APIs verificada contra servicios dependientes
